### PR TITLE
Add spawn points for players and mobs

### DIFF
--- a/entity_scenes/ItemSpawner.gd
+++ b/entity_scenes/ItemSpawner.gd
@@ -1,0 +1,42 @@
+extends Node
+
+const item = preload("res://entity_scenes/Item.tscn")
+var spawn_freq = rand_range(1, 8)
+var item_count = 0
+
+func _ready():
+	set_process(true)
+	_spawn()
+
+
+func _process(delta):
+	if $Container.get_child_count() > 0:
+		for entity in $Container.get_children():
+			_check_position(entity)
+
+
+# item spawning loop with irregular timer
+func _spawn():
+	
+	# TODO: make 'while' an infinite loop and find way to pause spawning
+	while item_count != 5:
+		randomize()
+		
+		var pickup = item.instance()
+		var pos = Vector2()
+		
+		pos.x = rand_range(0, get_viewport().get_visible_rect().size.x)
+		pos.y = rand_range(0, get_viewport().get_visible_rect().size.y * (3/4))
+		pickup.set_position(pos)
+		
+		$Container.add_child(pickup)
+		item_count = item_count + 1
+		yield(get_tree().create_timer(spawn_freq), "timeout")
+
+
+# despawn item if fallen off play area
+func _check_position(entity):
+	if entity.get_position().y > 650:
+		#print("Mob died")
+		entity.queue_free()
+		item_count = item_count - 1

--- a/entity_scenes/ItemSpawner.tscn
+++ b/entity_scenes/ItemSpawner.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://entity_scenes/ItemSpawner.gd" type="Script" id=1]
+
+[node name="ItemSpawner" type="Node" index="0"]
+
+script = ExtResource( 1 )
+_sections_unfolded = [ "Pause" ]
+
+[node name="Container" type="Node" parent="." index="0"]
+
+_sections_unfolded = [ "Pause" ]
+
+

--- a/entity_scenes/MobSpawnPoint.tscn
+++ b/entity_scenes/MobSpawnPoint.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=2]
+
+[node name="SpawnPoint" type="Node2D" index="0"]
+
+

--- a/entity_scenes/MobSpawner.gd
+++ b/entity_scenes/MobSpawner.gd
@@ -23,14 +23,19 @@ func _spawn():
 		randomize()
 		
 		var enemy = mob.instance()
-		var pos = Vector2()
+#		var pos = Vector2()
+#
+#		pos.x = rand_range(0, get_viewport().get_visible_rect().size.x)
+#		pos.y = rand_range(0, get_viewport().get_visible_rect().size.y * (3/4))
+#		enemy.set_position(pos)
+
+		for node in get_parent().get_children():
+			if node.get_name() == "MobSpawnPoints":
+				enemy.set_position(node.get_child(0).get_global_position())
+				$Container.add_child(enemy)
+				enemy_count = enemy_count + 1
+				break
 		
-		pos.x = rand_range(0, get_viewport().get_visible_rect().size.x)
-		pos.y = rand_range(0, get_viewport().get_visible_rect().size.y * (3/4))
-		enemy.set_position(pos)
-		
-		$Container.add_child(enemy)
-		enemy_count = enemy_count + 1
 		yield(get_tree().create_timer(spawn_freq), "timeout")
 
 

--- a/entity_scenes/Player.tscn
+++ b/entity_scenes/Player.tscn
@@ -51,7 +51,7 @@ custom_solver_bias = 0.0
 radius = 8.11261
 height = 1.83669
 
-[node name="Player" type="KinematicBody2D"]
+[node name="Player" type="KinematicBody2D" index="0"]
 
 position = Vector2( 864, 128 )
 scale = Vector2( 2, 2 )
@@ -72,6 +72,7 @@ _sections_unfolded = [ "Material", "Pause", "Transform", "Visibility", "Z Index"
 
 frames = SubResource( 2 )
 animation = "idle"
+frame = 1
 playing = true
 _sections_unfolded = [ "Material", "Pause", "Transform", "Visibility", "Z Index" ]
 
@@ -115,5 +116,7 @@ audio_bus_name = "Master"
 
 position = Vector2( 0, 1 )
 shape = SubResource( 3 )
+
+[node name="Inventory" type="Node" parent="." index="4"]
 
 

--- a/entity_scenes/PlayerSpawnPoint.tscn
+++ b/entity_scenes/PlayerSpawnPoint.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=2]
+
+[node name="SpawnPoint" type="Node2D"]
+
+

--- a/entity_scenes/PlayerSpawner.gd
+++ b/entity_scenes/PlayerSpawner.gd
@@ -19,30 +19,26 @@ func _spawn():
 	for entity in range(num_players):
 		
 		var new_player = player.instance()
-		var pos = Vector2()
-		
-		pos.x = get_viewport().get_visible_rect().size.x / 2
-		pos.y = get_viewport().get_visible_rect().size.y * (7 / 8)
-		new_player.set_position(pos)
-		
-		$Container.add_child(new_player)
+		for node in get_parent().get_children():
+			if node.get_name() == "PlayerSpawnPoints":
+				new_player.set_position(node.get_child(0).get_global_position())
+				$Container.add_child(new_player)
+				break
+	
 
 
 # special case after initial death has occured
 func _respawn():
 	var new_player = player.instance()
-	var pos = Vector2()
-		
-	pos.x = get_viewport().get_visible_rect().size.x / 2
-	pos.y = get_viewport().get_visible_rect().size.y * (7 / 8)
-	new_player.set_position(pos)
-	
-	$Container.add_child(new_player)
+	for node in get_parent().get_children():
+		if node.get_name() == "PlayerSpawnPoints":
+			new_player.set_position(node.get_child(0).get_global_position())
+			$Container.add_child(new_player)
+			break
 
 
 # despawn player if fallen off play area
 func _check_position(entity):
 	if entity.get_position().y > 650:
 		entity.queue_free()
-		#print("Player died")
 		_respawn()

--- a/environment_scenes/World.tscn
+++ b/environment_scenes/World.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://environment_scenes/World.gd" type="Script" id=1]
 [ext_resource path="res://assets/tilesets/CastleTileset.tres" type="TileSet" id=2]
 [ext_resource path="res://gui/HUD.tscn" type="PackedScene" id=3]
 [ext_resource path="res://entity_scenes/MobSpawner.tscn" type="PackedScene" id=4]
 [ext_resource path="res://entity_scenes/PlayerSpawner.gd" type="Script" id=5]
+[ext_resource path="res://entity_scenes/PlayerSpawnPoint.tscn" type="PackedScene" id=6]
+[ext_resource path="res://entity_scenes/MobSpawnPoint.tscn" type="PackedScene" id=7]
 
 [sub_resource type="RectangleShape2D" id=1]
 
@@ -74,6 +76,27 @@ transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 script = ExtResource( 5 )
 
 [node name="MobSpawner" parent="." index="3" instance=ExtResource( 4 )]
+
+[node name="PlayerSpawnPoints" type="Node2D" parent="." index="4"]
+
+[node name="SpawnPoint" parent="PlayerSpawnPoints" index="0" instance=ExtResource( 6 )]
+
+position = Vector2( 96, 480 )
+_sections_unfolded = [ "Transform", "Z Index" ]
+
+[node name="MobSpawnPoints" type="Node2D" parent="." index="5"]
+
+[node name="SpawnPoint" parent="MobSpawnPoints" index="0" instance=ExtResource( 7 )]
+
+position = Vector2( 320, 448 )
+
+[node name="SpawnPoint2" parent="MobSpawnPoints" index="1" instance=ExtResource( 7 )]
+
+position = Vector2( 608, 480 )
+
+[node name="SpawnPoint3" parent="MobSpawnPoints" index="2" instance=ExtResource( 7 )]
+
+position = Vector2( 928, 448 )
 
 [connection signal="body_entered" from="TileMap/Door" to="." method="_on_Door_body_entered"]
 


### PR DESCRIPTION
Spawnpoints available for placement in any given level for players and mobs (requires 'PlayerSpawnPoints' and 'MobSpawnPoints' nodes to be present in tree to serve as containers).

Also added a inventory node for Player to build off of, and the start of an ItemSpawner structure for random item spawns in level.