### PR TITLE
collision_layer constants added to a Base.gd file

### DIFF
--- a/Base.gd
+++ b/Base.gd
@@ -1,0 +1,5 @@
+extends Node
+
+const TILE_COLLISION_LAYER = 1
+const MOB_COLLISION_LAYER = 2
+const PLAYER_COLLISION_LAYER = 4

--- a/Base.tscn
+++ b/Base.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Base.gd" type="Script" id=1]
+
+[node name="Base" type="Node"]
+
+script = ExtResource( 1 )
+
+

--- a/entity_scenes/AnimatedEntity.gd
+++ b/entity_scenes/AnimatedEntity.gd
@@ -1,4 +1,4 @@
-extends KinematicBody2D
+extends "res://Base.gd"
 
 
 # Var instead of const to allow player leveling and mob scaling

--- a/entity_scenes/Mob.gd
+++ b/entity_scenes/Mob.gd
@@ -18,13 +18,13 @@ func _physics_process(delta):
 
 
 func _on_Area2D_body_entered(body):
-	if body.collision_layer == 4:
+	if body.collision_layer == PLAYER_COLLISION_LAYER:
 		update_state("attacking")
-	elif body.collision_layer == 1:
+	elif body.collision_layer == TILE_COLLISION_LAYER:
 		velocity.y = -2 * speed
 		
 
 
 func _on_Area2D_body_exited( body ):
-	if body.collision_layer == 4:
+	if body.collision_layer == PLAYER_COLLISION_LAYER:
 		update_state("walking")

--- a/entity_scenes/Player.gd
+++ b/entity_scenes/Player.gd
@@ -35,7 +35,7 @@ func _process(delta):
 
 func _on_Area2D_body_entered(body):
 	# If the body is an enemy, add it to the dictionary
-	if body.collision_layer == 2:	
+	if body.collision_layer == MOB_COLLISION_LAYER:	
 		enemies_in_range[body] = true
 	pass
 
@@ -43,6 +43,6 @@ func _on_Area2D_body_entered(body):
 
 func _on_Area2D_body_exited(body):
 	# If the body that left is an enemy, it is no longer a potential target for attacking
-	if body.collision_layer == 2:	
+	if body.collision_layer == MOB_COLLISION_LAYER:	
 		enemies_in_range.erase(body)
 	pass # replace with function body

--- a/environment_scenes/World.gd
+++ b/environment_scenes/World.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends "res://Base.gd"
 
 
 
@@ -41,7 +41,7 @@ func update_HUD_bars():
 
 # Triggered upon body entering the area. Used mainly for player entry. Triggers level end.
 func _on_GateArea_body_entered(body):
-	if body.collision_layer == 4:
+	if body.collision_layer == PLAYER_COLLISION_LAYER:
 		$Gate.set_texture(load("res://assets/animation_sprites/environment/closed_gate.png"))
 		$PlayerSpawner/Container.get_child(0).visible = false
 		$LevelEndTimer.start()


### PR DESCRIPTION
Previously, we were using raw numbers anytime we were checking collision_layer values. This will quickly get overwhelming as we start adding more collisions. Base.gd will serve as the script that all "generic" or "base" classes will extend:

AnimatedEntity.gd extends Base.gd

World.gd extends Base.gd

This makes the collision_layer constants accessible in all subclasses.