### PR TITLE
Stat bars overhauled to give them control over updates.

### DIFF
--- a/entity_scenes/Mob.gd
+++ b/entity_scenes/Mob.gd
@@ -3,13 +3,6 @@ extends "res://entity_scenes/AnimatedEntity.gd"
 onready var entities = get_node("/root/World/entities")
 
 func _ready():
-	health = MAX_HEALTH
-	mana = MAX_MANA
-	stamina = MAX_STAMINA
-	defense = MAX_DEFENSE
-	speed = MAX_SPEED
-	damage = MAX_DAMAGE
-
 	update_state("walking")	
 	who = "mob"
 
@@ -34,7 +27,6 @@ func take_damage(x):
 
 remote func set_health(h):
 	health = h
-	get_node("Health").update(health)
 
 remote func delete():
 	queue_free()

--- a/entity_scenes/Mob.tscn
+++ b/entity_scenes/Mob.tscn
@@ -1,11 +1,9 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://entity_scenes/AnimatedEntity.tscn" type="PackedScene" id=1]
 [ext_resource path="res://entity_scenes/Mob.gd" type="Script" id=2]
-[ext_resource path="res://gui/StatBar.tscn" type="PackedScene" id=3]
-[ext_resource path="res://gui/HealthForeground.tres" type="StyleBox" id=4]
-[ext_resource path="res://gui/HealthBackground.tres" type="StyleBox" id=5]
-[ext_resource path="res://entity_scenes/entity_resources/MobAnimationFrames.tres" type="SpriteFrames" id=6]
+[ext_resource path="res://entity_scenes/entity_resources/MobAnimationFrames.tres" type="SpriteFrames" id=3]
+[ext_resource path="res://gui/HealthBar.tscn" type="PackedScene" id=4]
 
 [node name="Mob" index="0" instance=ExtResource( 1 )]
 
@@ -14,21 +12,18 @@ collision_mask = 5
 script = ExtResource( 2 )
 _sections_unfolded = [ "Collision", "Material", "Pause", "Pickable", "Transform", "Visibility", "Z Index", "collision" ]
 
-[node name="Health" parent="." index="0" instance=ExtResource( 3 )]
-
-show_behind_parent = true
-margin_left = -17.0
-margin_top = -28.0
-margin_right = 13.0
-margin_bottom = -25.0
-custom_styles/fg = ExtResource( 4 )
-custom_styles/bg = ExtResource( 5 )
-
-[node name="Animations" parent="." index="1"]
+[node name="Animations" parent="." index="0"]
 
 scale = Vector2( 2, 2 )
-frames = ExtResource( 6 )
+frames = ExtResource( 3 )
 animation = "attacking"
 _sections_unfolded = [ "Material", "Pause", "Transform", "Visibility", "Z Index" ]
+
+[node name="Health" parent="." index="1" instance=ExtResource( 4 )]
+
+margin_left = -17.0
+margin_top = -25.0
+margin_right = 13.0
+margin_bottom = -22.0
 
 

--- a/environment_scenes/World.gd
+++ b/environment_scenes/World.gd
@@ -25,10 +25,8 @@ var menuBool = false #escape menu implementation
 func _ready():
 	get_tree().connect("server_disconnected", self, "_server_disconnected")
 	global_player.connect("player_disconnect", self, "player_disconnect")
-	
 	# tell server i'm ready to recieve player data
 	rpc_id(1, "feed_me_player_info", get_tree().get_network_unique_id())
-	
 	# set items to default amount (0)
 	for i in range(5):
 		inventory[i] = 0
@@ -37,6 +35,7 @@ remote func spawn(who, id, it_id = 0, b = 0):
 	print("spawn! " + who + " " + str(id))
 	if who == "mob":
 		var m = mob.instance()
+		m.get_node("Health").set_parent_entity(m)
 		m.set_name(str(id))
 		mobs.add_child(m)
 	elif who == "player":
@@ -64,6 +63,10 @@ remote func spawn(who, id, it_id = 0, b = 0):
 		new_item.set_name(str(id))
 		new_item.select_sprite(it_id)
 		items.add_child(new_item)
+	# Sets up the HUD bars so that they have access to the player whose stats they are reflecting
+	get_node("PlayerHUD/Stats/Health").set_parent_entity(local_player_instance)
+	get_node("PlayerHUD/Stats/Mana").set_parent_entity(local_player_instance)
+	get_node("PlayerHUD/Stats/Stamina").set_parent_entity(local_player_instance)
 	
 
 func player_disconnect(id):

--- a/environment_scenes/World.tscn
+++ b/environment_scenes/World.tscn
@@ -1,17 +1,14 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://environment_scenes/World.gd" type="Script" id=1]
 [ext_resource path="res://assets/tilesets/CastleTileset.tres" type="TileSet" id=2]
-[ext_resource path="res://gui/StatBar.tscn" type="PackedScene" id=3]
-[ext_resource path="res://gui/HealthForeground.tres" type="StyleBox" id=4]
-[ext_resource path="res://gui/HealthBackground.tres" type="StyleBox" id=5]
-[ext_resource path="res://gui/ManaForeground.tres" type="StyleBox" id=6]
-[ext_resource path="res://gui/ManaBackground.tres" type="StyleBox" id=7]
-[ext_resource path="res://gui/StaminaForeground.tres" type="StyleBox" id=8]
-[ext_resource path="res://assets/animation_sprites/environment/open_gate.png" type="Texture" id=9]
-[ext_resource path="res://gui/Menu.tscn" type="PackedScene" id=10]
-[ext_resource path="res://gui/MenuButton.tscn" type="PackedScene" id=11]
-[ext_resource path="res://assets/audio/House In a Forest Loop.ogg" type="AudioStream" id=12]
+[ext_resource path="res://gui/HealthBar.tscn" type="PackedScene" id=3]
+[ext_resource path="res://gui/ManaBar.tscn" type="PackedScene" id=4]
+[ext_resource path="res://gui/StaminaBar.tscn" type="PackedScene" id=5]
+[ext_resource path="res://assets/animation_sprites/environment/open_gate.png" type="Texture" id=6]
+[ext_resource path="res://gui/Menu.tscn" type="PackedScene" id=7]
+[ext_resource path="res://gui/MenuButton.tscn" type="PackedScene" id=8]
+[ext_resource path="res://assets/audio/House In a Forest Loop.ogg" type="AudioStream" id=9]
 
 [sub_resource type="RectangleShape2D" id=1]
 
@@ -50,7 +47,6 @@ __meta__ = {
 
 [node name="PlayerHUD" type="CanvasLayer" parent="." index="1"]
 
-editor/display_folded = true
 layer = 1
 offset = Vector2( 0, 0 )
 rotation = 0.0
@@ -76,35 +72,30 @@ size_flags_vertical = 1
 
 [node name="Health" parent="PlayerHUD/Stats" index="0" instance=ExtResource( 3 )]
 
-margin_left = 16.0
+margin_left = 46.0
+margin_top = 1.0
+margin_right = 146.0
+margin_bottom = 9.0
+
+[node name="Mana" parent="PlayerHUD/Stats" index="1" instance=ExtResource( 4 )]
+
+margin_left = 46.0
+margin_top = 9.0
+margin_right = 146.0
+margin_bottom = 17.0
+
+[node name="Stamina" parent="PlayerHUD/Stats" index="2" instance=ExtResource( 5 )]
+
+margin_left = 46.0
 margin_top = 17.0
-margin_right = 116.0
+margin_right = 146.0
 margin_bottom = 25.0
-custom_styles/fg = ExtResource( 4 )
-custom_styles/bg = ExtResource( 5 )
-
-[node name="Mana" parent="PlayerHUD/Stats" index="1" instance=ExtResource( 3 )]
-
-margin_left = 16.0
-margin_top = 25.0
-margin_right = 116.0
-margin_bottom = 33.0
-custom_styles/fg = ExtResource( 6 )
-custom_styles/bg = ExtResource( 7 )
-
-[node name="Stamina" parent="PlayerHUD/Stats" index="2" instance=ExtResource( 3 )]
-
-margin_left = 16.0
-margin_top = 33.0
-margin_right = 116.0
-margin_bottom = 41.0
-custom_styles/fg = ExtResource( 8 )
 
 [node name="Gate" type="Sprite" parent="." index="2"]
 
 editor/display_folded = true
 position = Vector2( 1101.91, 472.051 )
-texture = ExtResource( 9 )
+texture = ExtResource( 6 )
 
 [node name="GateArea" type="Area2D" parent="Gate" index="0"]
 
@@ -139,13 +130,13 @@ autostart = false
 
 [node name="projectiles" type="Node" parent="entities" index="3"]
 
-[node name="Menu" parent="." index="5" instance=ExtResource( 10 )]
+[node name="Menu" parent="." index="5" instance=ExtResource( 7 )]
 
-[node name="MenuButton" parent="." index="6" instance=ExtResource( 11 )]
+[node name="MenuButton" parent="." index="6" instance=ExtResource( 8 )]
 
 [node name="BackgroundMusic" type="AudioStreamPlayer" parent="." index="7"]
 
-stream = ExtResource( 12 )
+stream = ExtResource( 9 )
 volume_db = 0.0
 autoplay = true
 mix_target = 0

--- a/gui/HealthBar.gd
+++ b/gui/HealthBar.gd
@@ -1,0 +1,11 @@
+extends "res://gui/StatBar.gd"
+	
+	
+func _process(delta):
+	if parent_entity != null:
+		# Update the value of the bar each frame
+		update(parent_entity.health)
+		# If the parent entity's max health changed, we need to update the width
+		if parent_entity.MAX_HEALTH != max_value:
+			set_dimensions(parent_entity.MAX_HEALTH)
+			set_max_value(parent_entity.MAX_HEALTH)

--- a/gui/HealthBar.tscn
+++ b/gui/HealthBar.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://gui/StatBar.tscn" type="PackedScene" id=1]
+[ext_resource path="res://gui/HealthForeground.tres" type="StyleBox" id=2]
+[ext_resource path="res://gui/HealthBackground.tres" type="StyleBox" id=3]
+[ext_resource path="res://gui/HealthBar.gd" type="Script" id=4]
+
+[node name="HealthBar" instance=ExtResource( 1 )]
+
+custom_styles/fg = ExtResource( 2 )
+custom_styles/bg = ExtResource( 3 )
+script = ExtResource( 4 )
+
+

--- a/gui/ManaBar.gd
+++ b/gui/ManaBar.gd
@@ -1,0 +1,11 @@
+extends "res://gui/StatBar.gd"
+
+	
+func _process(delta):
+	if parent_entity != null:
+		# Update the value of the bar each frame
+		update(parent_entity.mana)
+		# If the parent entity's max mana changed, we need to update the width
+		if parent_entity.MAX_MANA != rect_size.x:
+			set_dimensions(parent_entity.MAX_MANA)
+			set_max_value(parent_entity.MAX_MANA)

--- a/gui/ManaBar.tscn
+++ b/gui/ManaBar.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://gui/StatBar.tscn" type="PackedScene" id=1]
+[ext_resource path="res://gui/ManaForeground.tres" type="StyleBox" id=2]
+[ext_resource path="res://gui/ManaBackground.tres" type="StyleBox" id=3]
+[ext_resource path="res://gui/ManaBar.gd" type="Script" id=4]
+
+[node name="ManaBar" instance=ExtResource( 1 )]
+
+custom_styles/fg = ExtResource( 2 )
+custom_styles/bg = ExtResource( 3 )
+script = ExtResource( 4 )
+
+

--- a/gui/StaminaBar.gd
+++ b/gui/StaminaBar.gd
@@ -1,0 +1,10 @@
+extends "res://gui/StatBar.gd"
+	
+func _process(delta):
+	if parent_entity != null:
+		# Update the value of the bar each frame
+		update(parent_entity.stamina)
+		# If the parent entity's max stamina changed, we need to update the width
+		if parent_entity.MAX_STAMINA != rect_size.x:
+			set_dimensions(parent_entity.MAX_STAMINA)
+			set_max_value(parent_entity.MAX_STAMINA)

--- a/gui/StaminaBar.tscn
+++ b/gui/StaminaBar.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://gui/StatBar.tscn" type="PackedScene" id=1]
+[ext_resource path="res://gui/StaminaForeground.tres" type="StyleBox" id=2]
+[ext_resource path="res://gui/StaminaBar.gd" type="Script" id=3]
+
+[node name="StaminaBar" index="0" instance=ExtResource( 1 )]
+
+custom_styles/fg = ExtResource( 2 )
+script = ExtResource( 3 )
+
+

--- a/gui/StatBar.gd
+++ b/gui/StatBar.gd
@@ -1,13 +1,24 @@
 extends ProgressBar
 
+# The entity whose stats it is reflecting (e.g., a player or a mob)
+var parent_entity = null
 
+
+# Gives the stat bar a reference to the parent entity
+func set_parent_entity(entity):
+	parent_entity = entity
+
+
+# Updates the current value of the stat bar
 func update(val):
 	value = val
 	
 
+# Sets the maximum value this stat bar can assume
 func set_max_value(val):
 	max_value = val
 	
 	
+# Sets the width and height of this stat bar
 func set_dimensions(width, height=8):
 	rect_size = Vector2(width, height)


### PR DESCRIPTION
- New `HealthBar`, `StaminaBar`, and `ManaBar` classes/scenes created for easier instancing
- A `StatBar` can now "hold on" to an entity and use it to update itself (e.g., `HealthBar` self-updates using its `parent_entity`'s `health` property)
- World no longer controls stat bar updates, and neither does Mob
