### PR TITLE
Lobby anchors set so it's centered when resized

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -23,7 +23,7 @@ Base="*res://Base.gd"
 
 window/dpi/allow_hidpi=true
 window/stretch/mode="2d"
-window/stretch/aspect="expand"
+window/stretch/aspect="keep"
 window/stretch/shrink="1"
 
 [editor_plugins]

--- a/screens/lobby_screen/lobby_screen.tscn
+++ b/screens/lobby_screen/lobby_screen.tscn
@@ -4,12 +4,16 @@
 [ext_resource path="res://screens/loading_screen/loading_screen.tscn" type="PackedScene" id=2]
 [ext_resource path="res://screens/lobby_screen/PlayerSlot.tscn" type="PackedScene" id=3]
 
-[node name="lobby_node" type="Control"]
+[node name="lobby_node" type="Control" index="0"]
 
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -512.0
+margin_top = -300.0
+margin_right = -512.0
+margin_bottom = -300.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 0


### PR DESCRIPTION
Turns out it was simpler than I thought. Just a matter of setting all anchors to 0.5 for centering.

